### PR TITLE
modi : lab2 change dockerfile FROM balenalib/rpi-raspbian:stretch

### DIFF
--- a/SmartX-Mini-2024 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10.md
+++ b/SmartX-Mini-2024 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10.md
@@ -564,7 +564,7 @@ cd ~/SmartX-mini/raspbian-flume
 Open `Dockerfile` and check it is correct.
 
 ```dockerfile
-FROM balenalib/rpi-raspbian:stretch
+FROM balenalib/rpi-raspbian:buster
 LABEL "maintainer"="Seungryong Kim <srkim@nm.gist.ac.kr>"
 
 #Update & Install wget, vim


### PR DESCRIPTION
지원 종료로 인한 buster 변경