### PR TITLE
Update Lab#1

### DIFF
--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
@@ -65,11 +65,12 @@ Download Site : <https://releases.ubuntu.com/22.04/>
 
 1. Select “Install Ubuntu” (Do not choose “Try Ubuntu”). The installation should be done in English.
 2. In the Keyboard layout step, select “English (US)”.
-3. In the Updates and other software step, under “What apps would you like to install to start with?”, choose “Minimal installation” and proceed to the next step.
-4. In the Installation type step, select “Erase disk and install Ubuntu”, then click “Install Now”.
-5. When the “Write the changes to disks?” prompt appears, click “Continue” to proceed.
-6. Configure the Location settings.
-7. In the “Who are you?” step, enter the User and Computer information as follows.
+3. If the Wireless tab appears, select “I don’t want to connect to a Wi-Fi network right now” and proceed.
+4. In the Updates and other software step, under “What apps would you like to install to start with?”, choose “Minimal installation” and proceed to the next step.
+5. In the Installation type step, select “Erase disk and install Ubuntu”, then click “Install Now”.
+6. When the “Write the changes to disks?” prompt appears, click “Continue” to proceed.
+7. On the Location settings screen, select “South Korea Time.”
+8. In the “Who are you?” step, enter the User and Computer information as follows.
 
    - Your name: gist
    - Your computer's name: nuc<The last three digits of the NUC’s IP address.>  
@@ -77,9 +78,9 @@ Download Site : <https://releases.ubuntu.com/22.04/>
    - Pick a username: gist
    - For the password, follow the instructions provided by the TAs.
 
-8. Once all settings are complete, click the button to proceed with the final installation.
-9. Once the installation is complete, click the “Restart Now” button to reboot the NUC.
-10. During the restart process, if you see the message “Please remove the installation medium, then press ENTER”, remove the installation USB and press ENTER.
+9. Once all settings are complete, click the button to proceed with the final installation.
+10. Once the installation is complete, click the “Restart Now” button to reboot the NUC.
+11. During the restart process, if you see the message “Please remove the installation medium, then press ENTER”, remove the installation USB and press ENTER.
 
   <details>
     <summary>
@@ -117,7 +118,7 @@ If an issue related to booting occurs, follow these steps.
 ### 2-2. NUC: Network Configuration
 
 - When the login screen appears, enter your account information to log in. You will now proceed with the initial network configuration.  
-  **(Important: If a window appears asking whether to update Ubuntu after logging in, make sure to select “Don’t Upgrade”!)**
+  <span style="color: red;"><b>(Important: If a window appears asking whether to update Ubuntu after logging in, make sure to select “Don’t Upgrade”!)</b></span>
 - ‘Temporary’ Network Configuration using GUI
 
   ![Network Configuration](./img/network_configuration.png)
@@ -225,10 +226,9 @@ If an issue related to booting occurs, follow these steps.
 
   Type your NUC's IP in `<your nuc ip>`and gateway IP in `<gateway ip>`(In this lab, **172.29.0.254** is the gateway IP. Please write it without parentheses.)
 
-  **Caution!**
-  If the NUC has two Ethernet ports, the eno1 interface may not be available. Use the ifconfig command to check the network-connected interfaces (enp88s0 or enp89s0).
-
-  For example, run the `ifconfig -a` command in the terminal and select the interface where RX and TX packets are not zero. Then, replace all occurrences of eno1 in the text with either enp88s0 or enp89s0, based on the detected network interface.
+  **Caution!**  
+  <span style="color: red;">
+  If the NUC has two Ethernet ports, the `eno1` interface may not be available. Use the ifconfig command to check the network-connected interfaces (`enp88s0` or `enp89s0`). For example, enter `ifconfig -a` in the terminal and select the interface where RX and TX packets are not zero. Then, replace all occurrences of `eno1` in the text with either `enp88s0` or `enp89s0`, depending on the active interface.</span>
 
   Add the contents below.
 
@@ -296,7 +296,9 @@ If an issue related to booting occurs, follow these steps.
 >       post-down ip link del dev vport_vFunction
 >   ```
 
-**Caution!** If the NUC has two Ethernet ports, the eno1 interface will not be available. Therefore, in the block below, replace eno1 with the interface you selected earlier (enp88s0 or enp89s0), choosing the one currently in use.
+**Caution!**  
+<span style="color: red;">
+If the NUC has two Ethernet ports, the `eno1` interface will not be available. Therefore, in the block below, replace `eno1` with the interface you selected earlier (`enp88s0` or `enp89s0`), choosing the one currently in use.</span>
 
 ```bash
 sudo systemctl restart systemd-resolved.service
@@ -317,7 +319,9 @@ We will make VM attaching vport_vFunction. You can think this TAP as a NIC(Netwo
 
 Add the ports eno1 and vport_vFunction to br0.
 
-**Caution!** If the NUC has two Ethernet ports, the eno1 interface will not be available. Therefore, in the block below, replace eno1 with the interface you selected earlier (enp88s0 or enp89s0), choosing the one currently in use.
+**Caution!**  
+<span style="color: red;">
+If the NUC has two Ethernet ports, the `eno1` interface will not be available. Therefore, in the block below, replace `eno1` with the interface you selected earlier (`enp88s0` or `enp89s0`), choosing the one currently in use.</span>
 
 ```bash
 sudo ovs-vsctl add-port br0 eno1   #change this if you are using two-port NUC
@@ -389,7 +393,8 @@ exit # Exit superuser mod
   Please type your **NUC's ip address** in `<Your ip address>`. (Please write it in the format 172.29.0.X, without parentheses.)
 
   **Caution!**  
-  If the NUC has two Ethernet ports, the eno1 interface may not be available. Use the ifconfig command to check the network-connected interfaces (enp88s0 or enp89s0).
+  <span style="color: red;">
+  If the NUC has two Ethernet ports, the `eno1` interface may not be available. Use the ifconfig command to check the network-connected interfaces (`enp88s0` or `enp89s0`).</span>
 
   ```bash
   sudo iptables -A FORWARD -i eno1 -j ACCEPT

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
@@ -118,7 +118,7 @@ If an issue related to booting occurs, follow these steps.
 ### 2-2. NUC: Network Configuration
 
 - When the login screen appears, enter your account information to log in. You will now proceed with the initial network configuration.  
-  <span style="color: red;"><b>(Important: If a window appears asking whether to update Ubuntu after logging in, make sure to select “Don’t Upgrade”!)</b></span>
+  <b>⚠️(Important: If a window appears asking whether to update Ubuntu after logging in, make sure to select “Don’t Upgrade”!)⚠️</b>
 - ‘Temporary’ Network Configuration using GUI
 
   ![Network Configuration](./img/network_configuration.png)
@@ -224,9 +224,9 @@ If an issue related to booting occurs, follow these steps.
 
   Type your NUC's IP in `<your nuc ip>`and gateway IP in `<gateway ip>`(In this lab, **172.29.0.254** is the gateway IP. Please write it without parentheses.)
 
-  **Caution!**  
-  <span style="color: red;">
-  If the NUC has two Ethernet ports, the `eno1` interface may not be available. Use the ifconfig command to check the network-connected interfaces (`enp88s0` or `enp89s0`). For example, enter `ifconfig -a` in the terminal and select the interface where RX and TX packets are not zero. Then, replace all occurrences of `eno1` in the text with either `enp88s0` or `enp89s0`, depending on the active interface.</span>
+  ⚠️ **Caution!** ⚠️  
+  <b>
+  If the NUC has two Ethernet ports, the `eno1` interface may not be available. Use the ifconfig command to check the network-connected interfaces (`enp88s0` or `enp89s0`). For example, enter `ifconfig -a` in the terminal and select the interface where RX and TX packets are not zero. Then, replace all occurrences of `eno1` in the text with either `enp88s0` or `enp89s0`, depending on the active interface.</b>
 
   Add the contents below.
 
@@ -294,9 +294,9 @@ If an issue related to booting occurs, follow these steps.
 >       post-down ip link del dev vport_vFunction
 >   ```
 
-**Caution!**  
-<span style="color: red;">
-If the NUC has two Ethernet ports, the `eno1` interface will not be available. Therefore, in the block below, replace `eno1` with the interface you selected earlier (`enp88s0` or `enp89s0`), choosing the one currently in use.</span>
+⚠️ **Caution!** ⚠️  
+<b>
+If the NUC has two Ethernet ports, the `eno1` interface will not be available. Therefore, in the block below, replace `eno1` with the interface you selected earlier (`enp88s0` or `enp89s0`), choosing the one currently in use.</b>
 
 ```bash
 sudo systemctl restart systemd-resolved.service
@@ -315,9 +315,9 @@ We will make VM attaching vport_vFunction. You can think this TAP as a NIC(Netwo
 
 Add the ports eno1 and vport_vFunction to br0.
 
-**Caution!**  
-<span style="color: red;">
-If the NUC has two Ethernet ports, the `eno1` interface will not be available. Therefore, in the block below, replace `eno1` with the interface you selected earlier (`enp88s0` or `enp89s0`), choosing the one currently in use.</span>
+⚠️ **Caution!** ⚠️  
+<b>
+If the NUC has two Ethernet ports, the `eno1` interface will not be available. Therefore, in the block below, replace `eno1` with the interface you selected earlier (`enp88s0` or `enp89s0`), choosing the one currently in use.</b>
 
 ```bash
 sudo ovs-vsctl add-port br0 eno1   #change this if you are using two-port NUC
@@ -386,9 +386,9 @@ sudo systemctl restart networking
 
   Please type your **NUC's ip address** in `<Your ip address>`. (Please write it in the format 172.29.0.X, without parentheses.)
 
-  **Caution!**  
-  <span style="color: red;">
-  If the NUC has two Ethernet ports, the `eno1` interface may not be available. Use the ifconfig command to check the network-connected interfaces (`enp88s0` or `enp89s0`).</span>
+  ⚠️ **Caution!** ⚠️  
+  <b>
+  If the NUC has two Ethernet ports, the `eno1` interface may not be available. Use the ifconfig command to check the network-connected interfaces (`enp88s0` or `enp89s0`).</b>
 
   ```bash
   sudo iptables -A FORWARD -i eno1 -j ACCEPT
@@ -604,8 +604,8 @@ sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gat
 When writing --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP], remove the brackets `[]` and use the format 172.29.0.X.  
 For example: --ipaddress=172.29.0.X/24 --gateway=172.29.0.254
 
-<span style="color: red;">If there were no issues, proceed to the next step.  
-If there was a typo or mistake while executing the `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]` command, execute `sudo ovs-docker del-port br0 veno1 c1` and then re-run `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]`.</span>
+<b>⚠️ If there were no issues, skip this part. ⚠  
+If there was a typo or mistake while executing the `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]` command, execute `sudo ovs-docker del-port br0 veno1 c1` and then re-run `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]`.</b>
 
 Enter to docker container
 

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
@@ -525,12 +525,7 @@ sudo sysctl -p
 To add the Docker repository, configure apt to support HTTPS and install the required packages.
 
 ```bash
-sudo apt update
 sudo apt install -y ca-certificates curl gnupg lsb-release
-```
-
-```bash
-sudo apt update
 ```
 
 Install Docker

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
@@ -474,7 +474,7 @@ sudo sysctl -p
      > IPv4 Method → Manual
      >
      > subnet: 172.29.0.0/24  
-     > Address: < your VM IP >  
+     > Address: < VM IP(Extra IP) >  
      > Gateway: 172.29.0.254  
      > Name Servers: 203.237.32.100
 

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
@@ -253,7 +253,7 @@ If an issue related to booting occurs, follow these steps.
 
   Save and quit the vim editor.
 
-> **This section is for explaining the above content. It does not need to be entered into a file again.**
+> ⚠️ **This section is for explaining the above content. It does not need to be entered into a file again.** ⚠️
 >
 > - Loopback Interface Configuration
 >   Automatically activate the loopback interface and configure it as a loopback (a virtual network interface that refers to itself).
@@ -396,7 +396,7 @@ sudo systemctl restart networking
   sudo iptables -t nat -A POSTROUTING -s 192.168.100.0/24 -o eno1 -j SNAT --to <Your ip address>
   ```
 
-> **This is an explanation of the above command. It does not need to be entered again.**
+> ⚠️ **This is an explanation of the above command. It does not need to be entered again.** ⚠️
 >
 > - Allow packet forwarding for incoming traffic on the eno1 interface.
 >

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
@@ -492,7 +492,7 @@ sudo sysctl -p
 
 - Installation Completed
 
-  Once the Ubuntu installation is complete inside the VM and you see the `Reboot Now` button, enter the following command in the terminal of Host OS to shut down the VM.
+  When the installation of Ubuntu inside the VM is complete and the `Reboot Now` button appears, ⚠️ **open a new terminal on the Host OS** and enter the following command to shut down the VM.
 
   ```bash
   sudo killall -9 kvm
@@ -504,7 +504,7 @@ sudo sysctl -p
   sudo kvm -m 1024 -name tt \
   -smp cpus=2,maxcpus=2 \
   -device virtio-net-pci,netdev=net0 \
-  -netdev tap,id=net0,ifname=vport_vFunction,script=no
+  -netdev tap,id=net0,ifname=vport_vFunction,script=no \
   -boot d vFunction22.img
   ```
 

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
@@ -597,13 +597,15 @@ Install OVS-docker utility in host machine **(Not inside of Docker container)**
 
 ```bash
 sudo docker start c1
-sudo ovs-docker del-port br0 veno1 c1
 sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]
 # please type gateway IP and docker container IP.
 ```
 
 When writing --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP], remove the brackets `[]` and use the format 172.29.0.X.  
 For example: --ipaddress=172.29.0.X/24 --gateway=172.29.0.254
+
+<span style="color: red;">If there were no issues, proceed to the next step.  
+If there was a typo or mistake while executing the `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]` command, execute `sudo ovs-docker del-port br0 veno1 c1` and then re-run `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]`.</span>
 
 Enter to docker container
 

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
@@ -356,8 +356,6 @@ sudo systemctl restart networking
   wget https://ftp.lanet.kr/ubuntu-releases/22.04.5/ubuntu-22.04.5-live-server-amd64.iso
   ```
 
-  Now we are ready to make VM.
-
 - Prepare for Ubuntu VM
 
   To Make a virtual disk image, enter this command.
@@ -376,7 +374,7 @@ sudo systemctl restart networking
   -device virtio-net-pci,netdev=net0 \
   -netdev tap,id=net0,ifname=vport_vFunction,script=no \
   -boot d vFunction22.img \
-  -cdrom ubuntu-22.04.6-live-server-amd64.iso \
+  -cdrom ubuntu-22.04.5-live-server-amd64.iso \
   -vnc :5 -daemonize \
   -monitor telnet:127.0.0.1:3010,server,nowait,ipv4 \
   -cpu host
@@ -393,7 +391,7 @@ sudo systemctl restart networking
   ```bash
   sudo iptables -A FORWARD -i eno1 -j ACCEPT
   sudo iptables -A FORWARD -o eno1 -j ACCEPT
-  sudo iptables -t nat -A POSTROUTING -s 192.168.100.0/24 -o eno1 -j SNAT --to <Your ip address>
+  sudo iptables -t nat -A POSTROUTING -s 192.168.100.0/24 -o eno1 -j SNAT --to <NUC IP address>
   ```
 
 > ⚠️ **This is an explanation of the above command. It does not need to be entered again.** ⚠️
@@ -414,7 +412,7 @@ sudo systemctl restart networking
 >   Translate packets from the internal network (192.168.100.0/24) to the host’s IP before forwarding them to the external network.
 >
 >   ```text
->   sudo iptables -t nat -A POSTROUTING -s 192.168.100.0/24 -o eno1 -j SNAT --to <Your ip address>
+>   sudo iptables -t nat -A POSTROUTING -s 192.168.100.0/24 -o eno1 -j SNAT --to <NUC ip address>
 >   ```
 
 Open /etc/sysctl.conf file.
@@ -458,12 +456,11 @@ sudo sysctl -p
   Installation Steps (Control using the 'Enter key' and the 'arrow keys'.)
 
   1. On the language selection screen, set the language to English.
-  2. **(Important)** On the “Installer update available” screen, select “Continue without updating”.
-  3. On the “Keyboard configuration” screen, set all options to English (US).
-  4. On the “Choose the type of installation” screen, ensure that “Ubuntu Server” is selected (marked with an (X)), then click Done.
-  5. Enter the “Network configuration” screen and click “Edit IPv4” as shown below.
+  2. On the “Keyboard configuration” screen, set all options to English (US).
+  3. On the “Choose the type of installation” screen, ensure that “Ubuntu Server” is selected (marked with an (X)), then click Done.
+  4. Enter the “Network configuration” screen and click “Edit IPv4” as shown below.
      ![Ubuntu Network](./img/ubuntu_network.png)
-  6. Configure the settings based on the information below.
+  5. Configure the settings based on the information below.
 
      > IPv4 Method → Manual
      >
@@ -474,11 +471,12 @@ sudo sysctl -p
 
      Please leave the “Search domains” field empty.
 
-     Also, when writing `<your VM IP>`, remove the brackets and use the format 172.29.0.X.
+     Also, when writing `< VM IP(Extra IP) >`, remove the brackets and use the format 172.29.0.X.
 
-  7. On the “Proxy configuration” screen, leave it blank and proceed to the next step.
-  8. On the “Ubuntu archive mirror configuration” screen, simply click Done to proceed.
-  9. On the “Storage configuration” screen, proceed without making any changes by continuously clicking Done. When the “Confirm destructive action” prompt appears, click Continue to proceed.
+  6. On the “Proxy configuration” screen, leave it blank and proceed to the next step.
+  7. On the “Ubuntu archive mirror configuration” screen, simply click Done to proceed.
+  8. **(Important)** On the “Installer update available” screen, select “Continue without updating”.
+  9. On the "Guided storage configuration", “Storage configuration” screens, proceed without making any changes by continuously clicking Done. When the “Confirm destructive action” prompt appears, click Continue to proceed.
   10. On the “Profile configuration” screen, enter the following details as shown below.
       - Your name: vm
       - Your servers name: vm<The last three digits of the VM’s IP address>  

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Eng.md
@@ -190,12 +190,10 @@ If an issue related to booting occurs, follow these steps.
 - To use manual network management with Open vSwitch (OVS), disable and remove systemd-networkd and Netplan.
 
   ```bash
-  sudo su # Enter superuser mod
-  systemctl stop systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
-  systemctl disable systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
-  systemctl mask systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
-  apt-get --assume-yes purge nplan netplan.io
-  exit # Exit superuser mod
+  sudo systemctl stop systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
+  sudo systemctl disable systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
+  sudo systemctl mask systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
+  sudo apt-get --assume-yes purge nplan netplan.io
   ```
 
 - DNS configuration
@@ -308,11 +306,9 @@ sudo ifup eno1  #change this if you are using two-port NUC
 Restart the whole interfaces.
 
 ```bash
-sudo su # Enter superuser mod
-systemctl unmask networking
-systemctl enable networking
-systemctl restart networking
-exit # Exit superuser mod
+sudo systemctl unmask networking
+sudo systemctl enable networking
+sudo systemctl restart networking
 ```
 
 We will make VM attaching vport_vFunction. You can think this TAP as a NIC(Network Interface Card) of VM.
@@ -336,11 +332,9 @@ Below is the figure you have configured so far.
 Restart the whole interfaces.
 
 ```bash
-sudo su # Enter superuser mod
-systemctl unmask networking
-systemctl enable networking
-systemctl restart networking
-exit # Exit superuser mod
+sudo systemctl unmask networking
+sudo systemctl enable networking
+sudo systemctl restart networking
 ```
 
 ### 2-3. NUC: Making VM with KVM
@@ -635,7 +629,7 @@ apt install -y iputils-ping
 Check connectivity with ping command from docker to VM.
 
 ```bash
-ping <VM IP address>
+ping <VM IP(Extra IP)>
 # please type this command in the container.
 ```
 

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
@@ -593,13 +593,15 @@ ctrl + p, q를 누르면 container를 종료하지 않고 container 밖으로 �
 
 ```bash
 sudo docker start c1
-sudo ovs-docker del-port br0 veno1 c1
 sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]
 # please type gateway IP and docker container IP.
 ```
 
 위의 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP] 작성 시에 `[]`은 빼고, 172.29.0.X의 형식으로 작성해주시기 바랍니다.  
 예를 들어, --ipaddress=172.29.0.X/24 --gateway=172.29.0.254
+
+<span style="color: red;"> 아무 문제가 없었다면, 다음 단계로 넘어갑니다.  
+만약, `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]` 명령어를 실행하는 과정에서 오타나 실수가 있었다면 `sudo ovs-docker del-port br0 veno1 c1` 명령어를 실행하고 다시 `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]`를 실행합니다.</span>
 
 Docker container 안으로 진입합니다.
 

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
@@ -247,7 +247,7 @@ Download Site : <https://releases.ubuntu.com/22.04/>
 
    파일을 저장하고 vim editor에서 나옵니다.
 
-   > **위의 내용에 대한 설명입니다. 따로 파일에 입력하지 않아도 됩니다.**
+   > ⚠️ **위의 내용에 대한 설명입니다. 따로 파일에 입력하지 않아도 됩니다.** ⚠️
    >
    > - Loopback 인터페이스 설정
    >   Loopback 인터페이스를 자동으로 활성화하고, loopback(자기 자신을 참조하는 가상 네트워크 인터페이스)으로 설정합니다.
@@ -390,7 +390,7 @@ sudo systemctl restart networking
   sudo iptables -t nat -A POSTROUTING -s 192.168.100.0/24 -o eno1 -j SNAT --to <Your ip address>
   ```
 
-> **위의 명령어에 대한 설명입니다. 다시 입력하지 않아도 됩니다.**
+> ⚠️ **위의 명령어에 대한 설명입니다. 다시 입력하지 않아도 됩니다.** ⚠️
 >
 > - 인터페이스 eno1에서 들어오는 패킷의 포워딩을 허용합니다.
 >

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
@@ -521,12 +521,7 @@ sudo sysctl -p
 Docker 리포지토리 추가를 위해 apt를 HTTPS 지원 가능하도록 설정하고, 필요한 패키지를 설치합니다.
 
 ```bash
-sudo apt update
 sudo apt install -y ca-certificates curl gnupg lsb-release
-```
-
-```bash
-sudo apt update
 ```
 
 Docker를 설치합니다.

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
@@ -468,7 +468,7 @@ sudo sysctl -p
      > IPv4 Method → Manual
      >
      > subnet: 172.29.0.0/24  
-     > Address: < your VM IP >  
+     > Address: < VM IP(Extra IP) >  
      > Gateway: 172.29.0.254  
      > Name Servers: 203.237.32.100
 

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
@@ -111,7 +111,7 @@ Download Site : <https://releases.ubuntu.com/22.04/>
 ### 2-2. NUC: Network Configuration
 
 - 로그인 화면이 보이면, 계정 정보를 입력하여 로그인합니다. 이제부터는 초기 네트워크 설정을 진행할 것입니다.  
-  <span style="color: red;"><b>(중요. 로그인 뒤에 Ubuntu를 업데이트할 것인지 묻는 창이 뜬다면 반드시 Don't Upgrade를 선택해야합니다!)</b></span>
+  <b>⚠️(중요. 로그인 뒤에 Ubuntu를 업데이트할 것인지 묻는 창이 뜬다면 반드시 Don't Upgrade를 선택해야합니다!)⚠️</b>
 - ‘Temporary’ Network Configuration using GUI
 
   ![Network Configuration](./img/network_configuration.png)
@@ -157,7 +157,7 @@ Download Site : <https://releases.ubuntu.com/22.04/>
 
 3. Install net-tools & ifupdown
 
-   - network 관련 유틸리티를 실행하기 위해 net-tools와 ifupdown을 설치합니다. 그리고 ip addr show 명령어를 통해 network interface 정보를 확인합니다.
+   - network 관련 유틸리티를 실행하기 위해 net-tools와 ifupdown을 설치합니다. 그리고 `ifconfig -a` 명령어를 통해 network interface 정보를 확인합니다.
 
    ```bash
    sudo apt install -y net-tools ifupdown
@@ -218,9 +218,9 @@ Download Site : <https://releases.ubuntu.com/22.04/>
 
    `<your nuc ip>`에 현재 nuc의 ip와 `<gateway ip>`에 gateway ip를 입력해주시기 바랍니다.(이때 괄호는 제외하고 입력해야 합니다.)
 
-   **주의!**  
-   <span style="color: red;">
-   NUC에 이더넷 포트가 두 개 있는 경우 `eno1`이라는 인터페이스가 없습니다. `ifconfig` 명령으로 네트워크에 연결된 인터페이스(`enp88s0` 또는 `enp89s0`)를 확인합니다. (예를 들어, 터미널에 `ifconfig -a` 명령어를 입력하고 RX 및 TX 패킷이 0이 아닌 인터페이스를 선택합니다.) 그리고 아래 텍스트의 `eno1`을 모두 `enp88s0` 또는 `enp89s0`으로 변경합니다.</span>
+   ⚠️ **주의!** ⚠️  
+   <b>
+   NUC에 이더넷 포트가 두 개 있는 경우 `eno1`이라는 인터페이스가 없습니다. `ifconfig` 명령으로 네트워크에 연결된 인터페이스(`enp88s0` 또는 `enp89s0`)를 확인합니다. (예를 들어, 터미널에 `ifconfig -a` 명령어를 입력하고 RX 및 TX 패킷이 0이 아닌 인터페이스를 선택합니다.) 그리고 아래 텍스트의 `eno1`을 모두 `enp88s0` 또는 `enp89s0`으로 변경합니다.</b>
 
    아래의 내용을 추가합니다.
 
@@ -288,9 +288,9 @@ Download Site : <https://releases.ubuntu.com/22.04/>
    >     post-down ip link del dev vport_vFunction
    >   ```
 
-**주의!**  
-<span style="color: red;">
-만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해주시기 바랍니다.(`enp88s0` 또는 `enp89s0` 중에서 현재 사용중인 것을 선택하면 됩니다.)</span>
+⚠️ **주의!** ⚠️  
+<b>
+만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해주시기 바랍니다.(`enp88s0` 또는 `enp89s0` 중에서 현재 사용중인 것을 선택하면 됩니다.)</b>
 
 ```bash
 sudo systemctl restart systemd-resolved.service
@@ -309,9 +309,9 @@ vport_vFunction을 연결한 가상 머신(VM)을 만들겠습니다. 이 TAP(vp
 
 'br0'에 포트 'eno1' 및 'vport_vFunction'을 추가합니다.
 
-**주의!**  
-<span style="color: red;">
-만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해야합니다.(`enp88s0` 또는 `enp89s0` 중에서 현재 사용 중인 것을 선택합니다.)</span>
+⚠️ **주의!** ⚠️  
+<b>
+만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해야합니다.(`enp88s0` 또는 `enp89s0` 중에서 현재 사용 중인 것을 선택합니다.)</b>
 
 ```bash
 sudo ovs-vsctl add-port br0 eno1   #change this if you are using two-port NUC
@@ -380,9 +380,9 @@ sudo systemctl restart networking
 
   **NUC's ip address**을 하단의 `<Your ip address>`에 기입합니다.(이때, **괄호는 지우고** 172.29.0.X의 형식으로 작성합니다.)
 
-  **주의!**  
-  <span style="color: red;">
-  만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해야 합니다.(`enp88s0` 또는 `enp89s0` 중에서 사용하고 있는 것을 선택해 적어줍니다.)</span>
+  ⚠️ **주의!** ⚠️  
+  <b>
+  만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해야 합니다.(`enp88s0` 또는 `enp89s0` 중에서 사용하고 있는 것을 선택해 적어줍니다.)</b>
 
   ```bash
   sudo iptables -A FORWARD -i eno1 -j ACCEPT
@@ -600,8 +600,8 @@ sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gat
 위의 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP] 작성 시에 `[]`은 빼고, 172.29.0.X의 형식으로 작성해주시기 바랍니다.  
 예를 들어, --ipaddress=172.29.0.X/24 --gateway=172.29.0.254
 
-<span style="color: red;"> 아무 문제가 없었다면, 다음 단계로 넘어갑니다.  
-만약, `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]` 명령어를 실행하는 과정에서 오타나 실수가 있었다면 `sudo ovs-docker del-port br0 veno1 c1` 명령어를 실행하고 다시 `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]`를 실행합니다.</span>
+<b> ⚠️ 아무 문제가 없었다면, 이 부분은 생략합니다. ⚠️  
+만약, `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]` 명령어를 실행하는 과정에서 오타나 실수가 있었다면 `sudo ovs-docker del-port br0 veno1 c1` 명령어를 실행하고 다시 `sudo ovs-docker add-port br0 veno1 c1 --ipaddress=[docker_container_IP]/24 --gateway=[gateway_IP]`를 실행합니다.</b>
 
 Docker container 안으로 진입합니다.
 

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
@@ -350,8 +350,6 @@ sudo systemctl restart networking
   wget https://ftp.lanet.kr/ubuntu-releases/22.04.5/ubuntu-22.04.5-live-server-amd64.iso
   ```
 
-  이제 VM을 만들 준비가 되었습니다.
-
 - Prepare for Ubuntu VM
 
   VM에서 사용할 가상 디스크 image를 만들기 위해, 아래의 명령어를 실행합니다.
@@ -370,7 +368,7 @@ sudo systemctl restart networking
   -device virtio-net-pci,netdev=net0 \
   -netdev tap,id=net0,ifname=vport_vFunction,script=no \
   -boot d vFunction22.img \
-  -cdrom ubuntu-22.04.6-live-server-amd64.iso \
+  -cdrom ubuntu-22.04.5-live-server-amd64.iso \
   -vnc :5 -daemonize \
   -monitor telnet:127.0.0.1:3010,server,nowait,ipv4 \
   -cpu host
@@ -387,7 +385,7 @@ sudo systemctl restart networking
   ```bash
   sudo iptables -A FORWARD -i eno1 -j ACCEPT
   sudo iptables -A FORWARD -o eno1 -j ACCEPT
-  sudo iptables -t nat -A POSTROUTING -s 192.168.100.0/24 -o eno1 -j SNAT --to <Your ip address>
+  sudo iptables -t nat -A POSTROUTING -s 192.168.100.0/24 -o eno1 -j SNAT --to <NUC IP address>
   ```
 
 > ⚠️ **위의 명령어에 대한 설명입니다. 다시 입력하지 않아도 됩니다.** ⚠️
@@ -408,7 +406,7 @@ sudo systemctl restart networking
 >   내부 네트워크(192.168.100.0/24)의 패킷을 호스트의 IP로 변환하여 외부로 전달합니다.
 >
 >   ```text
->   sudo iptables -t nat -A POSTROUTING -s 192.168.100.0/24 -o eno1 -j SNAT --to <Your ip address>
+>   sudo iptables -t nat -A POSTROUTING -s 192.168.100.0/24 -o eno1 -j SNAT --to <NUC IP address>
 >   ```
 
 아래의 명령어를 입력하여 /etc/sysctl.conf 파일을 엽니다.
@@ -452,12 +450,11 @@ sudo sysctl -p
   설치 단계 (Enter키와 방향키를 사용하여 설치를 진행합니다.)
 
   1. 언어 설정 화면에서 English로 설정합니다.
-  2. **(중요)** "Installer update available" 화면에서는 "Continue without updating"을 선택합니다.
-  3. "Keyboard configuration" 화면에서는 모든 부분을 English(US)로 설정합니다.
-  4. "Choose the type of installation" 화면에서는 "Ubuntu Server" 부분에 (X) 표시가 되어있는지 확인하고 Done을 누릅니다.
-  5. "Network configuration" 화면에 진입하여 아래와 같이 "Edit IPv4"를 눌러줍니다.
+  2. "Keyboard configuration" 화면에서는 모든 부분을 English(US)로 설정합니다.
+  3. "Choose the type of installation" 화면에서는 "Ubuntu Server" 부분에 (X) 표시가 되어있는지 확인하고 Done을 누릅니다.
+  4. "Network configuration" 화면에 진입하여 아래와 같이 "Edit IPv4"를 눌러줍니다.
      ![Ubuntu Network](./img/ubuntu_network.png)
-  6. 아래 내용을 참고하여 설정해줍니다.
+  5. 아래 내용을 참고하여 설정해줍니다.
 
      > IPv4 Method → Manual
      >
@@ -466,15 +463,14 @@ sudo sysctl -p
      > Gateway: 172.29.0.254  
      > Name Servers: 203.237.32.100
 
-     Search domains에는 아무것도 적지 않습니다!  
-      Please leave the “Search domains” field empty.
+     Search domains에는 아무것도 적지 않습니다!
 
-     그리고 위의 `< your VM IP >` 작성 시에 **괄호는 지우고** 172.29.0.X의 형식으로 작성해야 합니다.  
-      Also, when writing `<your VM IP>`, remove the brackets and use the format 172.29.0.X.
+     그리고 위의 `< VM IP(Extra IP) >` 작성 시에 **괄호는 지우고** 172.29.0.X의 형식으로 작성해야 합니다.
 
-  7. "Proxy configuration" 화면에서는 아무것도 입력하지 않고 넘어갑니다.
-  8. "Ubuntu archive mirror configuration" 화면에서도 Done을 눌러 넘어갑니다.
-  9. "Storage configuration" 화면에서도 내용을 수정하지 않고 Done을 계속 눌러서 넘어갑니다. 마지막에 "Confirm destructive action" 창이 뜨면 Continue를 눌러 넘어갑니다.
+  6. "Proxy configuration" 화면에서는 아무것도 입력하지 않고 넘어갑니다.
+  7. "Ubuntu archive mirror configuration" 화면에서도 Done을 눌러 넘어갑니다.
+  8. **(중요)** "Installer update available" 화면에서는 "Continue without updating"을 선택합니다.
+  9. "Guided storage configuration", "Storage configuration" 화면에서도 내용을 수정하지 않고 Done을 계속 눌러서 넘어갑니다. 마지막에 "Confirm destructive action" 창이 뜨면 Continue를 눌러 넘어갑니다.
   10. "Profile configuration" 화면에서는 아래와 같이 입력합니다.
       - Your name: vm
       - Your servers name: vm<VM IP주소의 마지막 3자리 숫자>  

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
@@ -64,11 +64,12 @@ Download Site : <https://releases.ubuntu.com/22.04/>
 
 1. Install Ubuntu를 선택합니다. (Try Ubuntu X) 언어는 English로 진행해야합니다.
 2. Keyboard layout 설정 단계에서도 "English(US)"로 설정합니다.
-3. Updates and other software 단계에서 "What apps would you like to install to start with?" 영역에서 "Minimal installation"을 선택하고 다음 단계로 넘어갑니다.
-4. Installation type 단계에서 "Erase disk and install Ubuntu"를 선택하고 "Install now" 버튼을 누릅니다.
-5. Write the changes to disks? 창이 뜨면 Continue를 눌러 계속 진행합니다.
-6. Location 설정을 합니다.
-7. User 정보와 Computer 정보를 입력하는 "Who are you" 단계에 진입했다면 다음과 같이 설정합니다.
+3. Wireless 탭이 뜨면, "I don't want to connect to a Wi-Fi network right now"를 선택하고 넘어갑니다.
+4. Updates and other software 단계에서 "What apps would you like to install to start with?" 영역에서 "Minimal installation"을 선택하고 다음 단계로 넘어갑니다.
+5. Installation type 단계에서 "Erase disk and install Ubuntu"를 선택하고 "Install now" 버튼을 누릅니다.
+6. Write the changes to disks? 창이 뜨면 Continue를 눌러 계속 진행합니다.
+7. Location 설정 화면에서 "South Korea Time"을 선택합니다.
+8. User 정보와 Computer 정보를 입력하는 "Who are you" 단계에 진입했다면 다음과 같이 설정합니다.
 
    - Your name: gist
    - Your computer's name: nuc<NUC IP주소의 마지막 3자리 숫자>  
@@ -76,9 +77,9 @@ Download Site : <https://releases.ubuntu.com/22.04/>
    - Pick a username: gist
    - 비밀번호의 경우, 조교의 안내에 따라 설정을 진행합니다.
 
-8. 모든 설정이 완료되었다면 버튼을 눌러 최종 설치를 진행합니다.
-9. 설치가 완료되면, "Restart now" 버튼을 눌러 NUC을 다시 시작합니다.
-10. 재시작 과정에서 "Please remove the installation medium, then press ENTER" 메세지가 보이면, 설치 USB를 제거한 뒤에 ENTER 키를 누릅니다.
+9. 모든 설정이 완료되었다면 버튼을 눌러 최종 설치를 진행합니다.
+10. 설치가 완료되면, "Restart now" 버튼을 눌러 NUC을 다시 시작합니다.
+11. 재시작 과정에서 "Please remove the installation medium, then press ENTER" 메세지가 보이면, 설치 USB를 제거한 뒤에 ENTER 키를 누릅니다.
 
   <details>
     <summary>에러 발생 시 참고(정상 설치가 되었다면 이 부분은 생략합니다.)</summary>
@@ -110,7 +111,7 @@ Download Site : <https://releases.ubuntu.com/22.04/>
 ### 2-2. NUC: Network Configuration
 
 - 로그인 화면이 보이면, 계정 정보를 입력하여 로그인합니다. 이제부터는 초기 네트워크 설정을 진행할 것입니다.  
-  **(중요. 로그인 뒤에 Ubuntu를 업데이트할 것인지 묻는 창이 뜬다면 반드시 Don't Upgrade를 선택해야합니다!)**
+  <span style="color: red;"><b>(중요. 로그인 뒤에 Ubuntu를 업데이트할 것인지 묻는 창이 뜬다면 반드시 Don't Upgrade를 선택해야합니다!)</b></span>
 - ‘Temporary’ Network Configuration using GUI
 
   ![Network Configuration](./img/network_configuration.png)
@@ -219,8 +220,9 @@ Download Site : <https://releases.ubuntu.com/22.04/>
 
    `<your nuc ip>`에 현재 nuc의 ip와 `<gateway ip>`에 gateway ip를 입력해주시기 바랍니다.(이때 괄호는 제외하고 입력해야 합니다.)
 
-   **주의!**
-   NUC에 이더넷 포트가 두 개 있는 경우 `eno1`이라는 인터페이스가 없습니다. `ifconfig` 명령으로 네트워크에 연결된 인터페이스(`enp88s0` 또는 `enp89s0`)를 확인합니다. (예를 들어, 터미널에 `ifconfig -a` 명령어를 입력하고 RX 및 TX 패킷이 0이 아닌 인터페이스를 선택합니다.) 그리고 아래 텍스트의 `eno1`을 모두 `enp88s0` 또는 `enp89s0`으로 변경합니다.
+   **주의!**  
+   <span style="color: red;">
+   NUC에 이더넷 포트가 두 개 있는 경우 `eno1`이라는 인터페이스가 없습니다. `ifconfig` 명령으로 네트워크에 연결된 인터페이스(`enp88s0` 또는 `enp89s0`)를 확인합니다. (예를 들어, 터미널에 `ifconfig -a` 명령어를 입력하고 RX 및 TX 패킷이 0이 아닌 인터페이스를 선택합니다.) 그리고 아래 텍스트의 `eno1`을 모두 `enp88s0` 또는 `enp89s0`으로 변경합니다.</span>
 
    아래의 내용을 추가합니다.
 
@@ -288,7 +290,9 @@ Download Site : <https://releases.ubuntu.com/22.04/>
    >     post-down ip link del dev vport_vFunction
    >   ```
 
-**주의!** 만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해주시기 바랍니다.(`enp88s0` 또는 `enp89s0` 중에서 현재 사용중인 것을 선택하면 됩니다.)
+**주의!**  
+<span style="color: red;">
+만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해주시기 바랍니다.(`enp88s0` 또는 `enp89s0` 중에서 현재 사용중인 것을 선택하면 됩니다.)</span>
 
 ```bash
 sudo systemctl restart systemd-resolved.service
@@ -310,7 +314,8 @@ vport_vFunction을 연결한 가상 머신(VM)을 만들겠습니다. 이 TAP(vp
 'br0'에 포트 'eno1' 및 'vport_vFunction'을 추가합니다.
 
 **주의!**  
-만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해야합니다.(`enp88s0` 또는 `enp89s0` 중에서 현재 사용 중인 것을 선택합니다.)
+<span style="color: red;">
+만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해야합니다.(`enp88s0` 또는 `enp89s0` 중에서 현재 사용 중인 것을 선택합니다.)</span>
 
 ```bash
 sudo ovs-vsctl add-port br0 eno1   #change this if you are using two-port NUC
@@ -382,7 +387,8 @@ exit # Exit superuser mod
   **NUC's ip address**을 하단의 `<Your ip address>`에 기입합니다.(이때, **괄호는 지우고** 172.29.0.X의 형식으로 작성합니다.)
 
   **주의!**  
-  만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해야 합니다.(`enp88s0` 또는 `enp89s0` 중에서 사용하고 있는 것을 선택해 적어줍니다.)
+  <span style="color: red;">
+  만약 NUC에 2개의 ethernet port가 있다면, `eno1` interface가 없습니다. 그러므로 하단의 block에서 `eno1`을 위에서 선택한 interface 중 하나로 변경해야 합니다.(`enp88s0` 또는 `enp89s0` 중에서 사용하고 있는 것을 선택해 적어줍니다.)</span>
 
   ```bash
   sudo iptables -A FORWARD -i eno1 -j ACCEPT

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
@@ -183,12 +183,10 @@ Download Site : <https://releases.ubuntu.com/22.04/>
    - Open vSwitch(OVS)를 기반으로 수동 네트워크 관리 방법을 사용하기 위해서 systemd-networkd 및 Netplan을 비활성화하고 제거합니다.
 
    ```bash
-   sudo su # Enter superuser mod
-   systemctl stop systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
-   systemctl disable systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
-   systemctl mask systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
-   apt-get --assume-yes purge nplan netplan.io
-   exit # Exit superuser mod
+   sudo systemctl stop systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
+   sudo systemctl disable systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
+   sudo systemctl mask systemd-networkd.socket systemd-networkd networkd-dispatcher systemd-networkd-wait-online
+   sudo apt-get --assume-yes purge nplan netplan.io
    ```
 
    - DNS configuration
@@ -302,11 +300,9 @@ sudo ifup eno1  #change this if you are using two-port NUC
 전체 interface를 다시 시작합니다.
 
 ```bash
-sudo su # Enter superuser mod
-systemctl unmask networking
-systemctl enable networking
-systemctl restart networking
-exit # Exit superuser mod
+sudo systemctl unmask networking
+sudo systemctl enable networking
+sudo systemctl restart networking
 ```
 
 vport_vFunction을 연결한 가상 머신(VM)을 만들겠습니다. 이 TAP(vport_vFunction)은 VM의 NIC(네트워크 인터페이스 카드)라고 생각하면 됩니다.
@@ -330,11 +326,9 @@ sudo ovs-vsctl show
 전체 interface를 다시 시작합니다.
 
 ```bash
-sudo su # Enter superuser mod
-systemctl unmask networking
-systemctl enable networking
-systemctl restart networking
-exit # Exit superuser mod
+sudo systemctl unmask networking
+sudo systemctl enable networking
+sudo systemctl restart networking
 ```
 
 ### 2-3. NUC: Making VM with KVM
@@ -631,7 +625,7 @@ apt install -y iputils-ping
 ping 명령어를 사용하여 Docker container 내부에서 VM으로 통신이 잘 이루어지는지 확인합니다.
 
 ```bash
-ping <VM IP address>
+ping <VM IP(Extra IP)>
 # please type this command in the container.
 ```
 

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-1. Box/Lab#1_Box_Kor.md
@@ -486,7 +486,7 @@ sudo sysctl -p
 
 - Installation Completed
 
-  VM 내에서 ubuntu의 설치가 완료되어 `Reboot Now` 버튼이 보이면, Host OS의 터미널에서 아래의 명령어를 입력하여 VM을 종료합니다.
+  VM 내에서 ubuntu의 설치가 완료되어 `Reboot Now` 버튼이 보이면, ⚠️ **Host OS의 터미널을 새로 하나 생성한 뒤에** 아래의 명령어를 입력하여 VM을 종료합니다.
 
   ```bash
   sudo killall -9 kvm
@@ -498,7 +498,7 @@ sudo sysctl -p
   sudo kvm -m 1024 -name tt \
   -smp cpus=2,maxcpus=2 \
   -device virtio-net-pci,netdev=net0 \
-  -netdev tap,id=net0,ifname=vport_vFunction,script=no
+  -netdev tap,id=net0,ifname=vport_vFunction,script=no \
   -boot d vFunction22.img
   ```
 


### PR DESCRIPTION
아래의 issue들이 해결되어, 반영 완료되었습니다.
- LAN port 설정과 관련해서 주의 표시를 더욱 잘 보이도록 수정했습니다.
https://github.com/SmartX-Labs/SmartX-Mini/issues/81

- VM의 OS를 설치하는 과정에서 순서가 잘못된 부분을 수정했습니다.
https://github.com/SmartX-Labs/SmartX-Mini/issues/82

- `Your VM IP`라는 표현을 `VM IP(Extra IP)`로 변경하였습니다.
https://github.com/SmartX-Labs/SmartX-Mini/issues/83

- `sudo su` 명령어를 사용하지 않도록 수정했습니다.
https://github.com/SmartX-Labs/SmartX-Mini/issues/84

- 불필요한 `apt update` 명령어 사용 부분을 제거했습니다.
https://github.com/SmartX-Labs/SmartX-Mini/issues/86

- `sudo ovs-docker del-port br0 veno1 c1` 명령어를 문제가 발생했을 경우에만 사용하도록 수정했습니다.
https://github.com/SmartX-Labs/SmartX-Mini/issues/87

아래의 issue들은 반영하지 않아도 괜찮은 것으로 논의, 결정되었습니다.
- VM kill & restart 관련
https://github.com/SmartX-Labs/SmartX-Mini/issues/85

- `sudo docker` 관련
https://github.com/SmartX-Labs/SmartX-Mini/issues/88