### PR TITLE
Update Lab#2, according to Issues

### DIFF
--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
@@ -224,7 +224,7 @@ curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.s
 sudo apt install -y git-lfs
 git lfs install
 git clone https://github.com/SmartX-Labs/SmartX-Mini.git
-cd ~/SmartX-Mini/SmartX-Mini-2024\ Collection/Experiment/Lab-2.\ InterConnect/
+cd ~/SmartX-Mini/SmartX-Mini-2025\ Collection/Experiment/Lab-2.\ InterConnect/
 ```
 
 <details>

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
@@ -531,17 +531,13 @@ Next, open the `/etc/hosts` file using a text editor.
 sudo vim /etc/hosts
 ```
 
-Add the following two lines at the bottom of the file:
-
+Add the following line(Pi IP Address & Hostname) at the bottom of the file:
+<!-- 
+  Pi IP만 적는 것으로 수정합니다.
+  REF: Issue #98
+-->
 ```text
-[NUC_IP] [NUC_HOSTNAME]
-[PI_IP] [PI_HOSTNAME]
-```
-```text
-# Example (When NUC's Hostname is `nuc`)
-
-172.29.0.XX        nuc 
-172.29.0.XX        pi 
+172.29.0.XX        [PI_HOSTNAME] 
 ```
 
 >  ⚠️ **Warning** ⚠️ 
@@ -569,14 +565,17 @@ Add the following two lines at the bottom of the file:
 
 #### 2-3-2. (PI) Hostname preparation for Kafka
 
-Perform the same steps on the Pi that were done on the NUC in section 2-4-1. Open the `/etc/hosts` file and add the following two lines.
+Perform the same steps on the Pi that were done on the NUC in section 2-3-1. Open the `/etc/hosts` file and add the following line(NUC IP Address & Hostname).
 
 ```bash
 sudo vim /etc/hosts
 ```
+<!-- 
+  NUC IP만 적는 것으로 수정합니다.
+  REF: Issue #98
+-->
 ```text
-[NUC_IP] [NUC_HOSTNAME]
-[PI_IP] [PI_HOSTNAME]
+172.29.0.XX        [NUC_HOSTNAME]
 ```
 
 >  ⚠️ **Warning** ⚠️

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
@@ -361,8 +361,6 @@ flash -u hypriotos-init.yaml -F network-config -d <Your SD Card Directory> hypri
 > ```
 > 
 
-Now, eject the SD card, insert it into the Pi, and power it on. The default login credentials are (ID: `pi`, Password: `1234`).
-
 > 📰 Note: About the `hypriotos-init.yaml` file
 > The `hypriotos-init.yaml` file is used as the `/boot/user-data` file on HypriotOS.  
 > The `/boot/user-data` file provides user-defined configurations to the instance during initialization. It defines user creation, hostname settings, and whether to automatically initialize `/etc/hosts`.  
@@ -374,7 +372,9 @@ Now, eject the SD card, insert it into the Pi, and power it on. The default logi
 
 #### 2-2-1. (PI) Check Network Configuration
 
-Now, connect a keyboard, mouse, and monitor to the **Pi** to proceed with the setup.
+Now, eject the SD card, insert it into the Pi, and power it on. The default login credentials are (ID: `pi`, Password: `1234`).
+
+Next, connect a keyboard, mouse, and monitor to the **Pi** to proceed with the setup.
 
 First, verify that the network interface is configured correctly by entering the following command in the shell:
 

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
@@ -932,6 +932,14 @@ If everything is configured correctly, you should see the message displayed in t
 
 ### 3-1. Lab Summary
 
+In this lab, we experienced interconnecting computer systems in two different ways.
+
+Through steps `2-1` to `2-3`, you prepared for the physical interconnection of two computer systems and ultimately verified their ability to communicate with each other using `ping`. Through this process, we explored and experienced the concept of <U>**Physical Interconnect**</U>.
+
+Afterward, multiple containers were deployed on the Box using Docker. In summary, from steps `2-4` to `2-6`, we confirmed that the SNMP data extracted by `Apache Flume` was transmitted through `Apache Kafka` and delivered to the Consumer. Through this, we verified that two functions (Producer ↔ Consumer) could interact and exchange data via Apache Kafka, allowing us to experience <U>**Data Interconnect**</U>.
+
+### 3-2. Finale
+
 Through this lab, we have answered the following two key questions:
 
 1. How can heterogeneous devices (e.g., NUC and Pi) be physically interconnected?

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
@@ -148,7 +148,7 @@ Now we will install HypriotOS on the Raspberry Pi. HypriotOS is a Debian-based o
 
 To install HypriotOS, insert the Micro SD card into a reader, and insert into the NUC.
 
-> ⚠️ **주의** ⚠️
+> ⚠️ **Warning** ⚠️
 >
 > **Please ensure that the Pi is <U>completely powered off</U>** before removing the SD card.
 >
@@ -247,7 +247,7 @@ wget https://github.com/hypriot/image-builder-rpi/releases/download/v1.12.3/hypr
 ls -alh # Check all files
 ```
 
-#### 2-1-2. (NUC) HypriotOS 설정 수정
+#### 2-1-2. (NUC) Edit Configuration of HypriotOS
 
 `network-config` file is used to configure network setting. Now we will open and edit this file to configure.
 
@@ -263,9 +263,9 @@ ls -alh # Check all files
 > 
 > So, warning agian, <U>**Do not change the file name.**</U>
 > 
-> 참조: https://cloudinit.readthedocs.io/en/stable/reference/datasources/nocloud.html#source-files
+> REF: https://cloudinit.readthedocs.io/en/stable/reference/datasources/nocloud.html#source-files
 
-> 📰 Info: What is `cloud-init`, and How it initializes the OS
+> 📰 Note: What is `cloud-init`, and How it initializes the OS
 >
 > `cloud-init` is a tool used to initialize cloud instances. It is widely utilized by public cloud providers such as AWS and Google Cloud, as well as for provisioning private cloud infrastructure and installing bare-metal systems.
 >
@@ -306,7 +306,7 @@ We will modify the `ethernet.eth0.addresses` field to assign an IP address to th
 
 These network settings will be automatically applied during the Pi's boot process through `cloud-init`.
 
-#### 2-1-3. (NUC) SD 카드에 HypriotOS 설치
+#### 2-1-3. (NUC) Flash SD Card for HypriotOS Install
 
 To install HypriotOS onto the SD card, we first need to identify where the SD card is mounted. We will use the `fdisk` command to locate a partition that matches the SD card's size.
 
@@ -335,7 +335,7 @@ flash -u hypriotos-init.yaml -F network-config -d <Your SD Card Directory> hypri
 > |`-d <path>`, `--device`| Path of Device which where OS be installed. |
 > |`~.img`, `~.img.zip`| Raspberry OS Image File |
 
-> 📰 참고: How to resolve `BLKRRPART failed: Device or resource busy` error
+> 📰 Note: How to resolve `BLKRRPART failed: Device or resource busy` error
 >
 > If this error occurs, the OS is installed successfully, but the `hypriotos-init.yaml` and `network-config` files are not copied to the SD card.
 >
@@ -366,7 +366,7 @@ flash -u hypriotos-init.yaml -F network-config -d <Your SD Card Directory> hypri
 > The `/boot/user-data` file provides user-defined configurations to the instance during initialization. It defines user creation, hostname settings, and whether to automatically initialize `/etc/hosts`.  
 > This file also contains the initial user credentials, so if you forget the ID/PW, refer to this file.
 >
-> 참고: https://cloudinit.readthedocs.io/en/stable/explanation/format.html
+> REF: https://cloudinit.readthedocs.io/en/stable/explanation/format.html
 
 ### 2-2. Raspberry PI network Configuration
 
@@ -388,7 +388,7 @@ Next, check the routing table using the following command:
 netstat -rn
 ```
 
-#### 2-2-2. (PI) 패키지 설치
+#### 2-2-2. (PI) Install Package
 
 To proceed with the lab, install the following packages on the Pi:
 
@@ -539,7 +539,7 @@ Add the following two lines at the bottom of the file:
 172.29.0.XX        pi 
 ```
 
->  ⚠️ **주의** ⚠️ 
+>  ⚠️ **Warning** ⚠️ 
 > 
 > For this lab, it is recommended to **set the hostname to an <U>easy-to-remember and simple</U> name**. <br>
 > The NUC's hostname must match the one recorded on the Pi's `/etc/hosts` file, as it will also be required during the Kafka configuration.
@@ -552,7 +552,7 @@ Add the following two lines at the bottom of the file:
 > ```
 > **Permanent change:**
 > ```bash
-> # 영구 수정
+> # Change Permanently
 > sudo hostnamectl set-hostname <new_name>
 > ```
 >
@@ -574,7 +574,7 @@ sudo vim /etc/hosts
 [PI_IP] [PI_HOSTNAME]
 ```
 
->  ⚠️ **주의** ⚠️
+>  ⚠️ **Warning** ⚠️
 >
 > The /etc/hosts file on the Pi is reset during boot due to cloud-init. <br>
 > If you want to preserve these settings after reboot, follow the guidelines below. 
@@ -647,7 +647,7 @@ Navigate to this directory using the command below.
 cd ~/SmartX-mini/ubuntu-kafka
 ```
 
-#### 2-5-2. (NUC) Dockerfile 확인
+#### 2-5-2. (NUC) Check Dockerfile
 
 Check that the `Dockerfile` in the current directory matches the expected contents.
 
@@ -680,7 +680,7 @@ WORKDIR /kafka
 > …
 > ```
 
-#### 2-5-3. (NUC) Docker Image 빌드
+#### 2-5-3. (NUC) Build Docker Image
 
 Once you have verified the `Dockerfile`, proceed to build the Docker image using the following command: 
 
@@ -689,11 +689,11 @@ sudo docker build --tag ubuntu-kafka .
 #You should type '.', so docker can automatically start to find `Dockerfile` in the current directory('.').
 ```
 
->  📰 참고: Basic Docker CLI Commands
+>  📰 Note: Basic Docker CLI Commands
 >
 > The following are common Docker CLI commands that you can use to manage containers:
 > 
-> 자세한 사항은 [Docker Official Document](https://docs.docker.com/engine/reference/commandline/cli/)를 참고해주시기 바랍니다.
+> For more information, Please refer to [Docker Official Document](https://docs.docker.com/engine/reference/commandline/cli/).
 >
 > |Command|Description|
 > |---|---|
@@ -708,7 +708,7 @@ sudo docker build --tag ubuntu-kafka .
 > You can use the first 4 characters of the container ID shown by `docker ps` as `<container id>`, as long as they are unique.
 >
 
-#### 2-5-4. (NUC) Docker Container 배치
+#### 2-5-4. (NUC) Deploy Docker Containers
 
 Once the `ubuntu-kafka` image is built, create and run the following Docker containers: `zookeeper`, `broker0`, `broker1`, `broker2`, `consumer`.
 
@@ -727,7 +727,7 @@ sudo docker run -it --net=host --name broker2 ubuntu-kafka
 sudo docker run -it --net=host --name consumer ubuntu-kafka
 ```
 
-#### 2-5-5. (NUC - `zookeeper` Container) Zookeeper 설정
+#### 2-5-5. (NUC - `zookeeper` Container) Configure Zookeeper
 
 First, access the `zookeeper` container to configure it. <br>
 Use the following command to check the `zookeeper.properties` file:
@@ -843,7 +843,7 @@ cd ~/SmartX-mini/raspbian-flume
 
 Open the `Dockerfile` and ensure the contents match the following configuration:
 
->  ⚠️ **주의** ⚠️
+>  ⚠️ **Warning** ⚠️
 >
 > Ensure the base image is set to `FROM balenalib/rpi-raspbian:buster`.
 >
@@ -906,7 +906,7 @@ Start the Flume agent using the following command:
 bin/flume-ng agent --conf conf --conf-file conf/flume-conf.properties --name agent -Dflume.root.logger=INFO,console
 ```
 
-> 📰️ 참고: If errors occur, verify that the following three values are consistent:
+> 📰️ Note: If errors occur, verify that the following three values are consistent:
 > 1. The NUC hostname in the Pi's `/etc/hosts` file.
 > 2. The broker hostname in `conf/flume-conf.properties` on the Pi.
 > 3. The hostname of NUC (check with the `hostname` command).

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Eng.md
@@ -847,15 +847,18 @@ cd ~/SmartX-mini/raspbian-flume
 
 Open the `Dockerfile` and ensure the contents match the following configuration:
 
->  ⚠️ **Warning** ⚠️
+>  ⚠️ <span style="color:red">**Warning**</span> ⚠️
 >
-> Ensure the base image is set to `FROM balenalib/rpi-raspbian:buster`.
+> <span style="color:red"> Ensure the base image is set to `FROM balenalib/rpi-raspbian:buster`, not `stretch`.</span>
 >
 > If you don't modify it, you may encounter the build failure, since `apt update` failed.
 
 ```dockerfile
 FROM balenalib/rpi-raspbian:buster
 LABEL "maintainer"="Seungryong Kim <srkim@nm.gist.ac.kr>"
+
+# (Optional; to speed-up the build procedure) Change apt repository to KAIST mirror server.
+RUN sed -i 's@archive.raspbian.org@ftp.kaist.ac.kr/raspbian@g'
 
 #Update & Install wget, vim
 RUN sudo apt update

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
@@ -350,9 +350,7 @@ flash -u hypriotos-init.yaml -F network-config -d <Your SD Card Directory> hypri
 > d   # 모든 파티션이 삭제될 때까지 반복 입력한다.
 > w   # 변경사항 저장
 > ```
-> 
-
-이제 SD 카드를 분리하여 다시 Pi에 삽입한 뒤, Pi의 전원을 켭니다. ID는 `pi`, Password는 `1234` 입니다.
+>
 
 > 📰 참고: `hypriotos-init.yaml` 파일에 관하여
 >
@@ -364,7 +362,9 @@ flash -u hypriotos-init.yaml -F network-config -d <Your SD Card Directory> hypri
 
 ### 2-2. Raspberry PI network Configuration
 
-#### 2-2-1. (PI) 네트워크 설정 확인인
+#### 2-2-1. (PI) 네트워크 설정 확인
+
+이제 SD 카드를 분리하여 다시 Pi에 삽입한 뒤, Pi의 전원을 켭니다. ID는 `pi`, Password는 `1234` 입니다.
 
 이제부터 키보드와 마우스, 모니터를 Pi에 연결하여 작업합니다.
 

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
@@ -218,7 +218,7 @@ curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.s
 sudo apt install -y git-lfs
 git lfs install
 git clone https://github.com/SmartX-Labs/SmartX-Mini.git
-cd ~/SmartX-Mini/SmartX-Mini-2024\ Collection/Experiment/Lab-2.\ InterConnect/
+cd ~/SmartX-Mini/SmartX-Mini-2025\ Collection/Experiment/Lab-2.\ InterConnect/
 ```
 
 <details>

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
@@ -522,17 +522,13 @@ hostname
 sudo vim /etc/hosts
 ```
 
-파일의 맨 아래에 다음의 두 줄을 추가합니다.
-
+파일의 맨 아래에 Pi의 IP 주소와 Hostname을 다음과 같이 추가합니다.
+<!-- 
+  Pi IP만 적는 것으로 수정합니다.
+  REF: Issue #98
+-->
 ```text
-[NUC_IP] [NUC_HOSTNAME]
-[PI_IP] [PI_HOSTNAME]
-```
-```text
-# 예시 (NUC의 Hostname이 `nuc`인 경우.)
-
-172.29.0.XX        nuc 
-172.29.0.XX        pi 
+172.29.0.XX        [PI_HOSTNAME] 
 ```
 
 >  ⚠️ **주의** ⚠️ 
@@ -559,14 +555,17 @@ sudo vim /etc/hosts
 
 #### 2-3-2. (PI) Hostname preparation for Kafka
 
-2-4-1에서 수행하였던 작업을 Pi에서 동일하게 수행합니다. `/etc/hosts` 파일을 열어 다음의 두 줄을 추가합니다.
+2-3-1에서 수행하였던 작업을 Pi에서 동일하게 수행합니다. `/etc/hosts` 파일을 열어 최하단에 NUC의 IP 주소와 Hostname을 다음과 같이 추가합니다.
 
 ```bash
 sudo vim /etc/hosts
 ```
+<!-- 
+  NUC IP만 적는 것으로 수정합니다.
+  REF: Issue #98
+-->
 ```text
-[NUC_IP] [NUC_HOSTNAME]
-[PI_IP] [PI_HOSTNAME]
+172.29.0.XX        [NUC_HOSTNAME]
 ```
 
 >  ⚠️ **주의** ⚠️

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
@@ -837,16 +837,19 @@ cd ~/SmartX-mini/raspbian-flume
 
 `Dockerfile`을 열어 내용이 하단과 동일한지 확인해주십시오.
 
->  ⚠️ **주의** ⚠️
+>  ⚠️ <span style="color:red">**주의**</span> ⚠️
 >
 > Repository의 Dockerfile은 `FROM balenalib/rpi-raspbian:stretch`로 지정되어있습니다. <br>
-> 반드시 이를 `FROM balenalib/rpi-raspbian:buster`로 수정해주시기 바랍니다.
+> <span style="color:red">반드시 이를 `FROM balenalib/rpi-raspbian:buster`로 수정해주시기 바랍니다.</span>
 >
 > 수정하지 않고 빌드하실 경우, 빌드 과정에서 `apt update`가 정상적으로 진행되지 않아 빌드가 실패합니다.
 
 ```dockerfile
 FROM balenalib/rpi-raspbian:buster
 LABEL "maintainer"="Seungryong Kim <srkim@nm.gist.ac.kr>"
+
+# (Optional; to speed-up the build procedure) Change apt repository to kaist mirror server.
+RUN sed -i 's@archive.raspbian.org@ftp.kaist.ac.kr/raspbian@g'
 
 #Update & Install wget, vim
 RUN sudo apt update

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
@@ -360,7 +360,7 @@ flash -u hypriotos-init.yaml -F network-config -d <Your SD Card Directory> hypri
 >
 > 참고: https://cloudinit.readthedocs.io/en/stable/explanation/format.html
 
-### 2-2. Raspberry PI network Configuration
+### 2-2. Raspberry PI 초기 환경 설정
 
 #### 2-2-1. (PI) 네트워크 설정 확인
 
@@ -396,8 +396,7 @@ sudo apt install -y git vim rdate openssh-server
 |`rdate`|시스템 시간을 외부 Time Server와 동기화하는 도구.|
 |`openssh-server`|SSH 서버 역할을 할 수 있도록 하는 패키지. 외부에서 Pi로 SSH를 통해 접근하기 위해 필요하다.|
 
-
-패키지 설치가 모두 완료되었다면, 다시 <U>**NUC으로 돌아갑니다**</U>. 이때, Pi는 NUC에서 SSH를 통해 접근할 예정이므로 <U>**끄지 않습니다**</U>.
+패키지 설치가 완료된 것을 확인한 이후, 다음 과정으로 넘어갑니다.
 
 > 📰 참고: `Certificate verification failed: The certificate is NOT Trusted` 오류
 >
@@ -427,37 +426,7 @@ sudo apt install -y git vim rdate openssh-server
 
 </details>
 
-#### 2-2-3. (NUC) SSH를 통해 Pi와 연결
-
-Pi에 `openssh-server`를 설치하였기 때문에, 외부에서 SSH를 통해 Pi에 접근할 수 있습니다. 이는 다음의 명령어를 통해 수행합니다. <br>
-(즉, 이제부터 모니터, 마우스, 키보드를 일일이 뽑고 꽂을 필요 없이, NUC에서 SSH로 Pi에 접근하면 됩니다.)
-
-```bash
-ssh pi@[PI_IP] #ID: pi PW: 1234
-```
-
-> 📰 참고: Fingerprint 오류
->
-> ![ssh key error](./img/ssh_duplicated.png)
->
-> 해당 오류는 접근할 IP 주소와 이와 연결된 SSH Key의 정보가 접근하려는 SSH Server의 Key와 다른 경우에 발생합니다.
-> 
-> 각 SSH Server는 고유의 SSH Key를 갖고 있습니다. <br>
-> 해당 Key는 SSH Client가 Server에 접근하였을 때 전달받으며, Client는 `~/.ssh/known_hosts`에 이를 IP와 함께 저장합니다. <br>
-> (하단의 이미지가 이 과정에 해당합니다.)<br>
-> ![ssh initial access](./img/ssh_initial_access.png)
-> 
-> Client는 해당 Server에 다시 접근할 때, `~/.ssh/known_hosts`에 저장된 데이터를 이용하여, 접근하려는 Server가 이전에 접근했던 Server와 동일한지 확인합니다. (이는 중간자 공격 보안 위협을 방지하기 위한 정책입니다.) <br>
-> 하지만 접근하려는 Server가 이전에 접근했었던 Server와 다를 경우, `ssh`는 위와 같은 오류를 출력하며 접근을 강제로 끊습니다.
->
-> 위의 오류를 해결하기 위해, 다음의 방법을 통해 이전의 Fingerprint를 삭제합니다. <br>
-> 이후 다시 SSH 연결을 시도합니다.
->
-> ```bash
-> ssh-keygen -f "/home/$(whoami)/.ssh/known_hosts" -R "[PI_IP_ADDRESS]"
-> ```
-
-### 2-3. (PI) 시간 동기화를 위한 `crontab` 설정
+#### 2-2-3. (PI) 시간 동기화를 위한 `crontab` 설정
 
 라즈베리 파이는 RTC가 없는 관계로, 전원 종료 후 약 17분 동안만 시스템 시간이 유지됩니다. <br>
 부팅 후 시간을 동기화하기 위해 `crontab`을 이용하여 부팅 완료 후 1분 뒤 `rdate`를 실행하도록 설정하겠습니다.
@@ -486,13 +455,48 @@ sudo crontab -e
 sudo reboot
 ```
 
-만약 시간이 여전히 일치하지 않는 경우, 하단의 명령어를 통해 설정할 수 있습니다.
+#### 2-2-4. (NUC) Pi 환경 확인
+
+이전 과정에서 Pi에 `openssh-server`를 설치하였기 때문에, 외부에서 SSH를 통해 Pi에 접근할 수 있습니다. 이는 다음의 명령어를 통해 수행합니다. <br>
+(즉, 이제부터 모니터, 마우스, 키보드를 일일이 뽑고 꽂을 필요 없이, NUC에서 SSH로 Pi에 접근하면 됩니다.)
+
+```bash
+ssh pi@[PI_IP] #ID: pi PW: 1234
+```
+
+> 📰 참고: Fingerprint 오류
+>
+> ![ssh key error](./img/ssh_duplicated.png)
+>
+> 해당 오류는 접근할 IP 주소와 이와 연결된 SSH Key의 정보가 접근하려는 SSH Server의 Key와 다른 경우에 발생합니다. (e.g. `openssh-server` 재설치 이후 접근 시도)
+> 
+> 각 SSH Server는 고유의 SSH Key를 갖고 있습니다. <br>
+> 해당 Key는 SSH Client가 Server에 접근하였을 때 전달받으며, Client는 `~/.ssh/known_hosts`에 이를 IP와 함께 저장합니다. <br>
+> (하단의 이미지가 이 과정에 해당합니다.)<br>
+> ![ssh initial access](./img/ssh_initial_access.png)
+> 
+> Client는 해당 Server에 다시 접근할 때, `~/.ssh/known_hosts`에 저장된 데이터를 이용하여, 접근하려는 Server가 이전에 접근했던 Server와 동일한지 확인합니다. (이는 중간자 공격 보안 위협을 방지하기 위한 정책입니다.) <br>
+> 하지만 접근하려는 Server가 이전에 접근했었던 Server와 다를 경우, `ssh`는 위와 같은 오류를 출력하며 접근을 강제로 끊습니다.
+>
+> 위의 오류를 해결하기 위해, 다음의 방법을 통해 이전의 Fingerprint를 삭제합니다. <br>
+> 이후 다시 SSH 연결을 시도합니다.
+>
+> ```bash
+> ssh-keygen -f "/home/$(whoami)/.ssh/known_hosts" -R "[PI_IP_ADDRESS]"
+> ```
+
+다음으로, 시간 설정을 확인합니다. 다음의 명령어를 입력합니다.
+```bash
+date
+```
+
+만약 시간이 여전히 일치하지 않는 경우, 하단의 명령어를 통해 직접 설정할 수 있습니다.
 
 ```bash
 sudo rdate -s time.bora.net
 ```
 
-### 2-4. Hostname 설정
+### 2-3. Hostname 설정
 
 네트워크와 연결된 모든 장비들은 고유의 IP 주소를 통해 서로를 식별하고 통신합니다.
 
@@ -504,7 +508,7 @@ sudo rdate -s time.bora.net
 
 이후에 이어질 실습 또한 IP 주소 대신 `hostname`을 이용해서 상호작용할 것입니다.
 
-#### 2-4-1. (NUC) Hostname preparation for Kafka
+#### 2-3-1. (NUC) Hostname preparation for Kafka
 
 먼저, `hostname` 명령어를 통해 NUC의 hostname을 확인합니다.
 
@@ -553,7 +557,7 @@ sudo vim /etc/hosts
 > 방법은 별도로 설명하지 않으며, <https://repost.aws/ko/knowledge-center/linux-static-hostname-rhel7-centos7>을 참고해주십시오.
 
 
-#### 2-4-2. (PI) Hostname preparation for Kafka
+#### 2-3-2. (PI) Hostname preparation for Kafka
 
 2-4-1에서 수행하였던 작업을 Pi에서 동일하게 수행합니다. `/etc/hosts` 파일을 열어 다음의 두 줄을 추가합니다.
 
@@ -582,7 +586,7 @@ sudo vim /etc/hosts
 > 3. `/etc/cloud/cloud.cfg`에서 `cloud_init_modules`의 `- update_etc_hosts`를 주석처리 합니다. 해당 모듈이 `/etc/hosts`의 재생성을 담당합니다.
 > 
 
-#### 2-4-3. (PI, NUC) Hostname 적용 확인
+#### 2-3-3. (PI, NUC) Hostname 적용 확인
 
 NUC에서 hostname을 이용하여 통신이 정상적으로 이루어지는지 확인합니다.
 
@@ -602,7 +606,7 @@ Pi에서 정상적인 통신은 하단과 같으며, Non-Reachable 등의 오류
 
 ![ping from pi](./img/ping_from_pi.png)
 
-### 2-5. (NUC) Kafka Deployment
+### 2-4. (NUC) Kafka Deployment
 
 NUC과 Pi가 Hostname을 이용하여 정상적으로 통신할 수 있게 되었으니, 이제부터 Docker를 통해 Apache Kafka를 배치하여 NUC과 Pi가 메세지를 교환할 수 있는 환경을 구성하도록 하겠습니다. (2가지 Interconnect 중 Data Interconnect에 해당합니다.)
 
@@ -616,7 +620,7 @@ NUC과 Pi가 Hostname을 이용하여 정상적으로 통신할 수 있게 되�
 |         broker2          | Host's IP  |     2     |      9092      |
 |         consumer         | Host's IP  |     -     |       -        |
 
-#### 2-5-1. (NUC) Clone repository from GitHub
+#### 2-4-1. (NUC) Clone repository from GitHub
 
 먼저, 컨테이너를 생성하기 위한 이미지 파일을 빌드할 것입니다. <br>
 빌드에 필요한 데이터가 포함된 Repository를 Clone해주시기 바랍니다.
@@ -638,7 +642,7 @@ git clone https://github.com/SmartX-Box/SmartX-mini.git
 cd ~/SmartX-mini/ubuntu-kafka
 ```
 
-#### 2-5-2. (NUC) Dockerfile 확인
+#### 2-4-2. (NUC) Dockerfile 확인
 
 디렉토리 내 `Dockerfile`이 하단과 동일한지 확인해주십시오.
 
@@ -671,7 +675,7 @@ WORKDIR /kafka
 > …
 > ```
 
-#### 2-5-3. (NUC) Docker Image 빌드
+#### 2-4-3. (NUC) Docker Image 빌드
 
 `Dockerfile`이 올바르게 작성되어 있다면, 이를 이용하여 `docker build`를 통해 Docker Image 생성을 진행하겠습니다. <br>
 하단의 명령을 입력하여 Image 생성을 진행해주십시오. 
@@ -700,7 +704,7 @@ sudo docker build --tag ubuntu-kafka .
 > 이때 `<container_id>`는 `docker ps` 기준 (겹치지만 않는다면) ID의 앞 4글자만 입력해도 정상적으로 처리됩니다.
 >
 
-#### 2-5-4. (NUC) Docker Container 배치
+#### 2-4-4. (NUC) Docker Container 배치
 
 `ubuntu-kafka` 이미지 생성이 완료된 경우, 다음의 명령어를 통해 Docker Container를 생성하겠습니다. <br>
 컨테이너 각각에게 `zookeeper`, `broker0`, `broker1`, `broker2`, `consumer`라는 이름을 붙이겠습니다. 
@@ -720,7 +724,7 @@ sudo docker run -it --net=host --name broker2 ubuntu-kafka
 sudo docker run -it --net=host --name consumer ubuntu-kafka
 ```
 
-#### 2-5-5. (NUC - `zookeeper` Container) Zookeeper 설정
+#### 2-4-5. (NUC - `zookeeper` Container) Zookeeper 설정
 
 먼저 `zookeeper` 컨테이너에 접근하여 설정을 진행하도록 하겠습니다. <br>
 다음의 명령어를 통해 `zookeeper.properties` 파일을 확인하도록 하겠습니다.
@@ -737,7 +741,7 @@ bin/zookeeper-server-start.sh config/zookeeper.properties
 ```
 이때, Zookeeper는 항상 Broker보다 먼저 실행되어있어야 합니다. 환경을 다시 구성하실 때 이 점 유의 바랍니다.
 
-#### 2-5-6. (NUC - `brokerN` Container) Broker 설정
+#### 2-4-6. (NUC - `brokerN` Container) Broker 설정
 
 다음으로 각 `broker` 컨테이너에 접근하여 설정을 진행하도록 하겠습니다. <br>
 하단의 명령어를 통해 설정 파일을 열어주시고, 하단의 이미지를 참고하여 각 Broker가 하단의 표와 같은 값을 갖도록 설정해주십시오. <br>
@@ -761,7 +765,7 @@ sudo vi config/server.properties
 bin/kafka-server-start.sh config/server.properties
 ```
 
-#### 2-5-7. (NUC - `consumer` Container) Consumer Topic 설정
+#### 2-4-7. (NUC - `consumer` Container) Consumer Topic 설정
 
 이제 Consumer 컨테이너에 접근하여 Kafka에 `resource`라는 Topic을 생성할 것입니다. <br>
 하단의 명령어를 통해 Topic을 생성해주십시오.
@@ -777,9 +781,9 @@ bin/kafka-topics.sh --list --zookeeper localhost:2181 # list all topic of zookee
 bin/kafka-topics.sh --describe --zookeeper localhost:2181 --topic resource # Check existence of topic `resource` of zookeeper in localhost:2181
 ```
 
-### 2-6. (PI) Flume on Raspberry PI
+### 2-5. (PI) Flume on Raspberry PI
 
-#### 2-6-1. (PI) Install Net-SNMP installation
+#### 2-5-1. (PI) Install Net-SNMP installation
 
 이제 Pi로 돌아가 다음의 명령어를 입력해 `Net-SNMP` 패키지를 설치해주십시오.
 
@@ -815,7 +819,7 @@ sudo vi /etc/snmp/snmpd.conf
 sudo systemctl restart snmpd.service
 ```
 
-#### 2-6-2. (PI) Clone repository from GitHub
+#### 2-5-2. (PI) Clone repository from GitHub
 
 Pi에서도 `SmartX-mini` Repository를 Clone하겠습니다.
 
@@ -830,7 +834,7 @@ Pi에서는 `flume`을 배치할 것이므로, `raspbian-flume`으로 이동해�
 cd ~/SmartX-mini/raspbian-flume
 ```
 
-#### 2-6-3. (PI) Check Dockerfile
+#### 2-5-3. (PI) Check Dockerfile
 
 `Dockerfile`을 열어 내용이 하단과 동일한지 확인해주십시오.
 
@@ -862,7 +866,7 @@ ADD flume-conf.properties /flume/conf/
 WORKDIR /flume
 ```
 
-#### 2-6-4. (PI) Build docker image
+#### 2-5-4. (PI) Build docker image
 
 설정이 완료된 이후, `docker build`를 통해 이미지를 빌드합니다. NUC보다 시간이 더 오래 걸리는 점 참고 바랍니다.
 
@@ -870,7 +874,7 @@ WORKDIR /flume
 sudo docker build --tag raspbian-flume .
 ```
 
-#### 2-6-5. (PI) Run flume on container
+#### 2-5-5. (PI) Run flume on container
 
 빌드가 완료된 이후, 컨테이너를 생성한 뒤 `flume`을 실행하도록 하겠습니다.
 
@@ -903,7 +907,7 @@ bin/flume-ng agent --conf conf --conf-file conf/flume-conf.properties --name age
 > 2. Pi의 `conf/flume-conf.properties`에 입력된 Broker의 hostname
 > 3. NUC의 hostname (`hostname`으로 확인되는 값)
 
-### 2-7. (NUC - `consumer` Container) Consume message from brokers
+### 2-6. (NUC - `consumer` Container) Consume message from brokers
 
 다음의 스크립트를 실행하여 Producer에서 전달한 메세지를 Consumer가 수신할 수 있는지 확인해보겠습니다.
 ```bash

--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
@@ -921,14 +921,22 @@ bin/kafka-console-consumer.sh --zookeeper localhost:2181 --topic resource --from
 
 ## 3. Review
 
-### 3-1. Lab Summary
+### 3-1. Lab 요약
+
+이번 실습에서 두 가지 방식으로 컴퓨터 시스템을 상호 연결하는 것을 체험해보았습니다.
+
+여러분은 `2-1`부터 `2-3`까지의 과정을 통해 두 개의 컴퓨터 시스템이 물리적으로 상호 연결되기 위한 준비를 진행하였으며, 최종적으로 `ping`을 통해 두 시스템이 서로 통신할 수 있다는 것을 확인하였습니다. 이러한 과정을 통해 <U>**Physical Interconnect**</U>에 대해 알아보고, 체험해보았습니다.
+
+이후 Docker를 통해 Box에 여러 Container를 배포하였습니다. 간단하게 요약하면, `2-4`부터 `2-6`을 통해 `Apache Flume`이 추출한 SNMP 데이터가 `Apache Kafka`를 거쳐 Consumer에게 전달되었음을 확인할 수 있었습니다. 이를 통해, 우리는 `Apache Kafka`를 매개로 하여 두 Function(Producer ↔ Consumer)이 Data를 주고 받으며 상호작용할 수 있음을 확인할 수 있었으며, <U>**Data Interconnect**</U>를 체험할 수 있었습니다. 
+
+### 3-2. Finale
 
 이번 실습을 통해 다음의 2개 질문에 답할 수 있습니다.
 
 1. 어떻게 이기종 장치(여기서는 NUC과 Pi)를 물리적으로 상호연결할 수 있는가?
 2. 어떻게 서로 다른 Box에 위치한 2개의 Function 간 Data Transfer(여기서는 Kafka Messaging)를 상호연결할 수 있는가?
 
-위의 질문을 통해 Physical Interconnect와 Data Interconnect를 명확하게 구분하실 수 있을 것입니다.
+위의 질문을 생각해보며, Physical Interconnect와 Data Interconnect에 대해 고민해볼 수 있는 시간을 가져보시기 바랍니다.
 
 > 실습에 참여하시느라 고생 많으셨습니다. <br>
 > 참여해주셔서 감사합니다.


### PR DESCRIPTION
피드백에 따라 Lab#2의 매뉴얼을 다음과 같이 수정합니다.  
세부 사항은 Commit Message를 참고해주시기 바랍니다.

- 경로 이동 Typo를 수정하였습니다. 
  - #90
- 가독성 차원으로 Pi 초기 계정 정보 안내 위치를 수정하였습니다. 
  - #91
- 영문 매뉴얼에서 번역되지 않은 한국어를 영어로 번역하였습니다.
- `openssh-server` 설치 이후 재부팅이 필요한 경우가 있어, 매뉴얼 구성을 일부 수정합니다.
  - #93 
- NUC과 Pi의 `/etc/hosts`을 설명하는 부분을 수정하였습니다. 
  - #95 
  - #98 
- Dockerfile 검토 시 일부 주의할 점을 강조하고, Pi의 Dockerfile에서 apt repo.을 mirror url로 수정할 수 있는 명령을 추가하였습니다.
  - #96 
  - #97 
- 마지막 Review에서 실습 과정 요약을 추가하였습니다.
  - #92 