### PR TITLE
Lab2 Typo 수정 (Issue #103)

### DIFF
--- a/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
+++ b/SmartX-Mini-2025 Collection/Experiment/Lab-2. InterConnect/Lab#2_InterConnect_v2R10_Kor.md
@@ -281,9 +281,9 @@ pwd # 현재 Directory가 "SmartX-Mini/SmartX-Mini-2025 Collection/Experiment/La
 sudo vim network-config
 ```
 
-`network-config`에서 `ehternet.eth0`은 Pi의 `eth0` 인터페이스 설정을 의미합니다. 즉, Pi가 사용할 IP 주소, DNS 주소, Gateway 주소를 설정하는 영역입니다.
+`network-config`에서 `ethernet.eth0`은 Pi의 `eth0` 인터페이스 설정을 의미합니다. 즉, Pi가 사용할 IP 주소, DNS 주소, Gateway 주소를 설정하는 영역입니다.
 
-해당 파일에서 `ehternets.eth0.addresses`를 수정하여 Pi에게 부여할 IP 주소를 지정하고, `ethernet.eth0.nameservers.addresses`를 수정하여 DNS 서버를 지정하겠습니다. (`ethernet.eth0.gateway4`는 Gateway의 IPv4 주소로, 별도의 안내가 없다면 수정하지 않습니다.)
+해당 파일에서 `ethernets.eth0.addresses`를 수정하여 Pi에게 부여할 IP 주소를 지정하고, `ethernet.eth0.nameservers.addresses`를 수정하여 DNS 서버를 지정하겠습니다. (`ethernet.eth0.gateway4`는 Gateway의 IPv4 주소로, 별도의 안내가 없다면 수정하지 않습니다.)
 
 ```yaml
 …


### PR DESCRIPTION
오타 수정입니다.
오타가 더 나올까봐, GPT 4o로 스캔 한번 더 돌렸습니다. 아마 추가적인 오타는 없을 것입니다.

피드백에 따라 다음과 같이 수정합니다.
- "2-1-2. HypriotOS 설정 수정"에서 `ehternet`이라는 오타를 `ethernet`으로 일괄 수정합니다.
  #103 